### PR TITLE
Display table search above frozen header

### DIFF
--- a/script/tablelayout_functions.js
+++ b/script/tablelayout_functions.js
@@ -97,6 +97,11 @@ window.tablelayout = window.tablelayout || {};
             $table.find('thead').remove();
         }
         $table.parent().prepend($frozenTable);
+        // move search above the table header
+        if ($table.parent().hasClass('hasSearch')) {
+            $table.parent().prepend($table.parent().find('.globalSearch'));
+        }
+
         var SCROLLBAR_WIDTH = 17;
         $frozenTable.wrap(jQuery('<div></div>').width(tableWidth + SCROLLBAR_WIDTH));
         var height = 0;


### PR DESCRIPTION
When the position of table header is frozen and the body is scrollable, the search field should remain above the table and not be pulled down between the head and the body.